### PR TITLE
Improve indexing UX and auto-pending

### DIFF
--- a/assets/fulltext-index.js
+++ b/assets/fulltext-index.js
@@ -82,15 +82,16 @@
     const url = $('.wpui-url-ft').val().trim();
     if (!id && !url){ uiToast('Informe ID ou URL.', 'error'); return; }
     setBusy($btn, true, 'Indexando...');
-    const json = await callAPI('fulltext/index-one', {id, url, force_reindex: true, mode:'manual'}, 'wpui_fulltext_index_one');
+    const json = await callAPI('fulltext/index-one', {id, url, force_reindex: false, mode:'manual'}, 'wpui_fulltext_index_one');
     setBusy($btn, false);
     if (json && (json.status==='ok' || json.success)){
       updateCounters('ft', {indexed:1});
       uiToast('Indexado com sucesso.');
+      $('.wpui-id-ft, .wpui-url-ft').val('');
       $('.wpui-refresh').trigger('click');
     } else if (json && json.status==='already_indexed'){
-      uiToast('Já indexado. Reindex feito.', 'success');
-      $('.wpui-refresh').trigger('click');
+      uiToast(WPUI.i18n.already, 'error');
+      $('.wpui-id-ft, .wpui-url-ft').val('');
     } else {
       uiToast('Falha ao indexar.', 'error');
     }
@@ -121,8 +122,16 @@
     // Refresh (forçar clean reload da página atual)
     $('.wpui-refresh').off('click').on('click', function(e){
       e.preventDefault();
-      const href = $(this).attr('href') || window.location.href;
-      window.location.href = href;
+      window.location.reload();
+    });
+
+    // Search as you type
+    $('#wpui-ft-search-input').on('keyup', function(){
+      const q = $(this).val().toLowerCase();
+      $('table.wp-list-table tbody tr').each(function(){
+        const t = $(this).find('td.column-post_title').text().toLowerCase();
+        $(this).toggle(t.indexOf(q) !== -1);
+      });
     });
   }
 

--- a/assets/structure-index.js
+++ b/assets/structure-index.js
@@ -97,11 +97,12 @@
     const url = $('.wpui-url-st').val().trim();
     if (!id && !url){ uiToast('Informe ID ou URL.', 'error'); return; }
     setBusy($btn, true, 'Indexando...');
-    const json = await callAPI('structure/index-one', {id, url, force_reindex: true, mode:'manual'}, 'wpui_structure_index_one');
+    const json = await callAPI('structure/index-one', {id, url, force_reindex: false, mode:'manual'}, 'wpui_structure_index_one');
     setBusy($btn, false);
     if (json && (json.status==='ok' || json.success)){
       updateCounters('st', {indexed:1});
       uiToast('Estrutura indexada.');
+      $('.wpui-id-st, .wpui-url-st').val('');
       $('.wpui-refresh').trigger('click');
     } else if (json && json.status==='no_items'){
       uiToast('Sem estrutura suficiente (mín. 3 itens).', 'error');
@@ -214,8 +215,16 @@
     // Refresh
     $('.wpui-refresh').off('click').on('click', function(e){
       e.preventDefault();
-      const href = $(this).attr('href') || window.location.href;
-      window.location.href = href;
+      window.location.reload();
+    });
+
+    // Search as you type
+    $('#wpui-st-search-input').on('keyup', function(){
+      const q = $(this).val().toLowerCase();
+      $('table.wp-list-table tbody tr').each(function(){
+        const t = $(this).find('td.column-post_title').text().toLowerCase();
+        $(this).toggle(t.indexOf(q) !== -1);
+      });
     });
   }
 

--- a/includes/class-fulltext-indexer.php
+++ b/includes/class-fulltext-indexer.php
@@ -67,6 +67,12 @@ class Fulltext_Indexer {
         return null;
     }
 
+    /** Remove o índice de um post específico */
+    public function unindex($post_id){
+        global $wpdb;
+        $wpdb->delete($this->table, ['post_id'=>intval($post_id)]);
+    }
+
     /** Hash simples do conteúdo para comparação */
     protected function content_hash($content){
         return md5(wp_strip_all_tags((string)$content));

--- a/includes/class-instruction-indexer.php
+++ b/includes/class-instruction-indexer.php
@@ -83,6 +83,12 @@ class Instruction_Indexer {
         return null;
     }
 
+    /** Remove o índice de um post para reprocessamento */
+    public function unindex($post_id){
+        global $wpdb;
+        $wpdb->delete($this->table, ['post_id'=>intval($post_id)]);
+    }
+
     /** Normaliza texto (minúsculas, sem acentos, sem pontuação) */
     protected function normalize($text){
         $text = wp_strip_all_tags((string)$text);

--- a/includes/class-unified-admin.php
+++ b/includes/class-unified-admin.php
@@ -66,7 +66,7 @@ class Admin {
             'counts_ft' => $counts_ft,
             'counts_st' => $counts_st,
             'i18n' => [
-                'already' => __('Instrução já está indexada. Deseja reindexar?','wp-unified-indexer'),
+                'already' => __('Instrução já indexada.','wp-unified-indexer'),
                 'error' => __('Ocorreu um erro.','wp-unified-indexer'),
                 'saved' => __('Sinônimos salvos.','wp-unified-indexer'),
                 'deleted' => __('Item excluído.','wp-unified-indexer'),

--- a/wp-unified-indexer.php
+++ b/wp-unified-indexer.php
@@ -33,6 +33,22 @@ require_once WPUI_DIR . 'includes/class-fulltext-index-table.php';
 require_once WPUI_DIR . 'includes/class-instruction-index-table.php';
 require_once WPUI_DIR . 'includes/class-instruction-audit-table.php';
 
+// Invalida índices ao atualizar posts publicados
+add_action('save_post', function($post_id, $post, $update){
+    if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) return;
+    if ($post->post_status !== 'publish') return;
+
+    $ft = new \WPUI\Fulltext_Indexer();
+    if (in_array($post->post_type, $ft->post_types(), true)) {
+        $ft->unindex($post_id);
+    }
+
+    $st = new \WPUI\Instruction_Indexer();
+    if (in_array($post->post_type, $st->post_types(), true)) {
+        $st->unindex($post_id);
+    }
+}, 10, 3);
+
 // Bootstrap
 add_action('plugins_loaded', function(){
     if (is_admin()) { \WPUI\Admin::init(); }


### PR DESCRIPTION
## Summary
- prevent reindexing already indexed posts and warn the user
- clear manual indexing fields and enable search-as-you-type filtering
- drop stale indexes when posts are updated to keep pending counters accurate

## Testing
- `php -l includes/class-fulltext-indexer.php`
- `php -l includes/class-instruction-indexer.php`
- `php -l wp-unified-indexer.php`
- `php -l includes/class-unified-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68b94d9c4444832c9aace94a8510e546