### PR TITLE
Fix structure tab counter and sequential ID generation

### DIFF
--- a/assets/structure-index.js
+++ b/assets/structure-index.js
@@ -64,7 +64,8 @@
   function updateCounters(kind, delta){
     const c = (kind==='st') ? WPUI.counts_st : WPUI.counts_ft;
     if (delta && typeof delta.indexed === 'number'){
-      c.indexed += delta.indexed;
+      c.indexed = parseInt(c.indexed, 10) + delta.indexed;
+      c.published = parseInt(c.published, 10);
       c.pending = Math.max(0, c.published - c.indexed);
     }
     const wrap = $('.wpui-wrap');

--- a/includes/class-instruction-indexer.php
+++ b/includes/class-instruction-indexer.php
@@ -108,6 +108,7 @@ class Instruction_Indexer {
         preg_match_all('/<(h[2-6])[^>]*>(.*?)<\/\\1>/is', $html, $matches, PREG_SET_ORDER);
         $items = [];
 
+        $counter = 1;
         foreach($matches as $m){
             $title = wp_strip_all_tags($m[2]);
 
@@ -116,7 +117,8 @@ class Instruction_Indexer {
                 $item_id = $mm[1];
                 $item_title = trim($mm[2]) ?: $title;
             } else {
-                $item_id = '';
+                // Gera um ID sequencial para itens sem numeração
+                $item_id = (string) $counter++;
                 $item_title = $title;
             }
 


### PR DESCRIPTION
## Summary
- Ensure structure indexing counters update using numeric values
- Assign sequential IDs to structure items lacking explicit numbering

## Testing
- `php -l includes/class-instruction-indexer.php`
- `node --check assets/structure-index.js`


------
https://chatgpt.com/codex/tasks/task_e_68b98dfe5698832c84061ede68d6eb6b